### PR TITLE
Swe5 clear seating plan

### DIFF
--- a/src/main/resources/static/css/course.css
+++ b/src/main/resources/static/css/course.css
@@ -47,3 +47,8 @@ td.course-seat:hover {
 h1 {
     font-size: 3rem;
 }
+
+.modal#modal-danger-clear-student, .modal#modal-danger-reset-template {
+    top: calc(50% - 350px);
+    padding-top: 50px;
+}

--- a/src/main/resources/static/js/course.js
+++ b/src/main/resources/static/js/course.js
@@ -60,7 +60,7 @@ $(document).ready(function () {
             });
 
         $('#modal-danger-clear-student-continue').on('click', function(e){
-            //GATED BY ISSUE#SWE43
+            /* GATED BY https://github.com/SWE-4103-Group-3/Project/issues/43
             var seats = grid.getSeats();
             $.ajax({
                 type: "post",
@@ -74,6 +74,7 @@ $(document).ready(function () {
                     toastr.success("Successfully cleared student seating!");
                 }
             });
+            */
         });
     });
 

--- a/src/main/resources/static/js/course.js
+++ b/src/main/resources/static/js/course.js
@@ -1,0 +1,111 @@
+$(document).ready(function () {
+    var grid;
+    var courseID = $('input#courseID').attr('value');
+
+    $.ajax({
+        type: "get",
+        url: "/courses/" + courseID,
+        dataType: "json",
+        success: function (data, status) {
+            grid = new Grid({
+                rows: data.rows,
+                cols: data.cols,
+                seats: data.seats,
+                states: ["open", "closed", "reserved"]
+            });
+            $('#course-seating-grid').append(grid.el);
+        },
+        error: function (data, status) {
+            console.log(data);
+        }
+    });
+
+    $('#editsave').on('click', function (e) {
+        if (grid.editable) {
+            grid.editable = false;
+            $('#editsave').html('Edit');
+            var seats = grid.getSeats();
+
+            $.ajax({
+                type: "post",
+                url: "/courses/" + courseID + "/seats",
+                data: JSON.stringify(seats),
+                contentType: "application/json",
+                error: function (data, status) {
+                    console.log(data);
+                },
+                success: function() {
+                    toastr.success("Successfully saved seating template!");
+                }
+            });
+        } else {
+            grid.editable = true;
+            $('#editsave').html('Save');
+        }
+    });
+
+    //Clear Student Ties to Seats
+    $('#editclearseating').on('click', function(e){
+        $('#modal-danger-clear-student')
+            .css('display', 'block')
+            .css('opacity', '1');
+
+        $('#modal-danger-clear-student-close-top')
+            .add('#modal-danger-clear-student-close-bottom')
+            .add('#modal-danger-clear-student-continue')
+            .on('click', function(e){
+                $('#modal-danger-clear-student')
+                    .css('display', 'none')
+                    .css('opacity', '0');
+            });
+
+        $('#modal-danger-clear-student-continue').on('click', function(e){
+            //GATED BY ISSUE#SWE43
+            var seats = grid.getSeats();
+            $.ajax({
+                type: "post",
+                url: "/courses/" + courseID + "/seats",
+                data: JSON.stringify(seats),
+                contentType: "application/json",
+                error: function (data, status) {
+                    console.log(data);
+                },
+                success: function() {
+                    toastr.success("Successfully cleared student seating!");
+                }
+            });
+        });
+    });
+
+    $('#editcleartemplate').on('click', function(e){
+        $('#modal-danger-reset-template')
+            .css('display', 'block')
+            .css('opacity', '1');
+
+        $('#modal-danger-reset-template-close-top')
+            .add('#modal-danger-reset-template-close-bottom')
+            .add('#modal-danger-reset-template-continue')
+            .on('click', function(e){
+                $('#modal-danger-reset-template')
+                    .css('display', 'none')
+                    .css('opacity', '0');
+            });
+
+        $('#modal-danger-reset-template-continue').on('click', function(e) {
+            grid.clearSeats();
+
+            $.ajax({
+                type: "post",
+                url: "/courses/" + courseID + "/seats",
+                data: JSON.stringify(grid.getSeats()),
+                contentType: "application/json",
+                error: function (data, status) {
+                    console.log(data);
+                },
+                success: function() {
+                    toastr.success("Successfully reset seat template!");
+                }
+            });
+        });
+    });
+});

--- a/src/main/resources/static/js/grid.js
+++ b/src/main/resources/static/js/grid.js
@@ -72,6 +72,12 @@ function Grid(opt) {
         }
     };
 
+    this.clearSeats = function() {
+        for (var i = 0; i < this.cells.length; i++)
+            for(var j = 0; j < this.cells[i].length; j++)
+                this.cells[i][j].setState(0);
+    };
+
     this.render = function () {
         var percent = 100 / this.cols;
         for (var i = 0; i < this.rows; i++) {

--- a/src/main/resources/templates/course.twig
+++ b/src/main/resources/templates/course.twig
@@ -44,7 +44,7 @@
             </div>
         </div>
     </div>
-    <!--Clear Student Seating Warning Modal-->
+    <!--Reset Seating Template Warning Modal-->
     <div class="modal fade" id="modal-danger-reset-template" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
         <div class="modal-dialog modal-notify modal-danger" role="document">
             <div class="modal-content">

--- a/src/main/resources/templates/course.twig
+++ b/src/main/resources/templates/course.twig
@@ -6,6 +6,7 @@
 {% endblock %}
 
 {% block content %}
+    <input type="hidden" id="courseID" name="courseID" value="{{ course.id }}"/>
     <div class="course-editor-body">
         <div class="course-editor-title">
             <h1>{{ course.name }}</h1>
@@ -15,6 +16,56 @@
         </div>
         <div class="course-editor-controls">
             <button id="editsave" type="button" class="btn btn-primary">Edit</button>
+            <button id="editclearseating" type="button" class="btn btn-primary">Clear Student Seating</button>
+            <button id="editcleartemplate" type="button" class="btn btn-primary">Reset Seat Template</button>
+        </div>
+    </div>
+    <!--Clear Student Seating Warning Modal-->
+    <div class="modal fade" id="modal-danger-clear-student" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+        <div class="modal-dialog modal-notify modal-danger" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <p class="heading lead">Clear Student Seating</p>
+                    <button type="button" id=modal-danger-clear-student-close-top" class="close" data-dismiss="modal" aria-label="Close">
+                        <span aria-hidden="true" class="white-text">&times;</span>
+                    </button>
+                </div>
+                <div class="modal-body">
+                    <div class="text-center">
+                        <i class="fa fa-check fa-4x mb-3 animated rotateIn"></i>
+                        <p>Are you sure you wish to clear student seating? This will remove students from their assigned seating.
+                        The grid dimensions and seat states will be preserved.</p>
+                    </div>
+                </div>
+                <div class="modal-footer justify-content-center">
+                    <a type="button" id="modal-danger-clear-student-continue" class="btn btn-primary-modal">Continue<i class="fa fa-diamond ml-1"></i></a>
+                    <a type="button" id="modal-danger-clear-student-close-bottom" class="btn btn-outline-secondary-modal waves-effect" data-dismiss="modal">Take me back!</a>
+                </div>
+            </div>
+        </div>
+    </div>
+    <!--Clear Student Seating Warning Modal-->
+    <div class="modal fade" id="modal-danger-reset-template" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+        <div class="modal-dialog modal-notify modal-danger" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <p class="heading lead">Reset Seat Template</p>
+                    <button type="button" id="modal-danger-reset-template-close-top" class="close" data-dismiss="modal" aria-label="Close">
+                        <span aria-hidden="true" class="white-text">&times;</span>
+                    </button>
+                </div>
+                <div class="modal-body">
+                    <div class="text-center">
+                        <i class="fa fa-check fa-4x mb-3 animated rotateIn"></i>
+                        <p>Are you sure you wish to reset your seating template? This will remove students from their assigned seating
+                        and clear the states of all the seats in this template to 'open'.</p>
+                    </div>
+                </div>
+                <div class="modal-footer justify-content-center">
+                    <a type="button" id="modal-danger-reset-template-continue" class="btn btn-primary-modal">Continue<i class="fa fa-diamond ml-1"></i></a>
+                    <a type="button" id="modal-danger-reset-template-close-bottom" class="btn btn-outline-secondary-modal waves-effect" data-dismiss="modal">Take me back!</a>
+                </div>
+            </div>
         </div>
     </div>
 {% endblock %}
@@ -22,49 +73,5 @@
 {% block script %}
     {{ parent() }}
     <script type="text/javascript" src="/static/js/grid.js"></script>
-    <script>
-        $(document).ready(function () {
-            var grid;
-            $.ajax({
-                type: "get",
-                url: "/courses/{{ course.id }}",
-                dataType: "json",
-                success: function (data, status) {
-                    grid = new Grid({
-                        rows: data.rows,
-                        cols: data.cols,
-                        seats: data.seats,
-                        states: ["open", "closed", "reserved"]
-                    });
-                    $('#course-seating-grid').append(grid.el);
-                },
-                error: function (data, status) {
-                    console.log(data);
-                }
-            });
-
-            $('#editsave').on('click', function (e) {
-                if (grid.editable) {
-                    grid.editable = false;
-                    $('#editsave').html('Edit');
-                    var seats = grid.getSeats();
-                    console.log(seats);
-                    $.ajax({
-                        type: "post",
-                        url: "/courses/{{ course.id }}/seats",
-                        data: JSON.stringify(seats),
-                        contentType: "application/json",
-                        error: function (data, status) {
-                            console.log(data);
-                        }
-                    });
-
-                } else {
-                    grid.editable = true;
-                    $('#editsave').html('Save');
-                }
-            });
-        });
-    </script>
+    <script type="text/javascript" src="/static/js/course.js"></script>
 {% endblock %}
-

--- a/src/main/resources/templates/course.twig
+++ b/src/main/resources/templates/course.twig
@@ -9,7 +9,7 @@
     <input type="hidden" id="courseID" name="courseID" value="{{ course.id }}"/>
     <div class="course-editor-body">
         <div class="course-editor-title">
-            <h1>{{ course.name }}</h1>
+            <h1>{{ course.name }} <span style="color: grey;font-size:smaller;">{{ course.section }}</span></h1>
         </div>
         <div class="course-editor-grid">
             <div id="course-seating-grid"></div>


### PR DESCRIPTION
## Fixes #5 

### Changes Proposed in this Pull Request:
- Added two buttons to the course view; `Clear Student Seating` and `Reset Seat Template`
- Moved inline JS from course.twig into its own js file
- Implemented button functionality (see additional comments below)
- Added warning modal dialog, displayed when the user presses `Clear Student Seating` or `Reset Seat Template`
- Minor code refactors
- Added small notification card when user modifies the course template to let them know it worked.

### Images:
##### Before:
![image](https://user-images.githubusercontent.com/22732449/32417160-9beb1b9a-c22b-11e7-8fea-aa45874d07bf.png)

##### Upon pressing save:
![image](https://user-images.githubusercontent.com/22732449/32417164-a5f037f6-c22b-11e7-9fbb-aba29cd73d97.png)

##### Warning Modal:
![image](https://user-images.githubusercontent.com/22732449/32417171-ceeba690-c22b-11e7-9ef9-688b9a85462a.png)

##### After resetting template:
![image](https://user-images.githubusercontent.com/22732449/32417180-e67d6dfc-c22b-11e7-891e-f1d518483413.png)

### Additional Comments and Documentation:
The `Clear Student Seating` button is currently commented out because the functionality is gated by work currently being done in [SWE43](https://github.com/SWE-4103-Group-3/Project/issues/43).
@jacsmith21 Once this is merged, this will likely cause some merge conflicts with your current branch for SWE43. Just wanted to let you know :)